### PR TITLE
📦 Bump versions of multiple dependencies to address vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.21</version>
+            <version>1.26.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.9</version>
+            <version>1.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.14.1</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,12 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <groupId>com.example</groupId>
     <artifactId>my-app</artifactId>
     <version>1.0-SNAPSHOT</version>
-
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
-
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -132,7 +127,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-configuration2</artifactId>
-            <version>2.7</version>
+            <version>2.10.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -170,7 +165,6 @@
             <version>3.1</version>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-vfs2</artifactId>
-            <version>2.8.0</version>
+            <version>2.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.3</version>
+            <version>2.12.7.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>5.0.0</version>
+            <version>5.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| Component | CVE ID  | Severity | Description       |
|-------|-------|-----|-----------|
| org.apache.poi:poi-ooxml:5.0.0 | CVE-2025-31672 | Unknown  | Apache POI OOXML Vulnerable to Improper Input Validation in<br>OOXML File Parsing |
| org.apache.commons:commons-configuration2:2.7 | CVE-2024-29133 | Medium  | Apache Commons Configuration: StackOverflowError calling<br>ListDelimiterHandler.flatten(Object, int) with a cyclical<br>object tree |
| org.apache.commons:commons-configuration2:2.7 | CVE-2024-29131 | High  | Apache Commons Configuration: StackOverflowError adding<br>property in AbstractListDelimiterHandler.flattenIterator() |
| org.apache.commons:commons-configuration2:2.7 | CVE-2022-33980 | Critical  | Code injection in Apache Commons Configuration |
| org.apache.commons:commons-text:1.9 | CVE-2022-42889 | Critical  | Apache Commons Text performs variable interpolation, allowing<br>properties to be dynamically evaluated and expanded. The<br>standard format for interpolation is "${prefix:name}", where<br>"prefix" is used to locate an instance of<br>org.apache.commons.text.lookup.StringLookup that performs the<br>interpolation. Starting with version 1.5 and continuing<br>through 1.9, the set of default Lookup instances included<br>interpolators that could result in arbitrary code execution<br>or contact with remote servers. These lookups are: - "script"<br>- execute expressions using the JVM script execution engine<br>(javax.script) - "dns" - resolve dns records - "url" - load<br>values from urls, including from remote servers Applications<br>using the interpolation defaults in the affected versions may<br>be vulnerable to remote code execution or unintentional<br>contact with remote servers if untrusted configuration values<br>are used. Users are recommended to upgrade to Apache Commons<br>Text 1.10.0, which disables the problematic interpolators by<br>default. |
| org.apache.commons:commons-vfs2:2.8.0 | CVE-2025-27553 | High  | Apache Commons VFS Has Relative Path Traversal Vulnerability |
| org.apache.commons:commons-vfs2:2.8.0 | CVE-2025-30474 | Medium  | Apache Commons VFS Exposure of Sensitive Information to an<br>Unauthorized Actor |
| org.apache.logging.log4j:log4j-core:2.14.1 | CVE-2021-45046 | Critical  | # Impact The fix to address<br>[CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228)<br>in Apache Log4j 2.15.0 was incomplete in certain non-default<br>configurations. This could allow attackers with control over<br>Thread Context Map (MDC) input data when the logging<br>configuration uses a non-default Pattern Layout with either a<br>Context Lookup (for example, $${ctx:loginId}) or a Thread<br>Context Map pattern (%X, %mdc, or %MDC) to craft malicious<br>input data using a JNDI Lookup pattern resulting in a remote<br>code execution (RCE) attack. ## Affected packages Only the<br>`org.apache.logging.log4j:log4j-core` package is directly<br>affected by this vulnerability. The<br>`org.apache.logging.log4j:log4j-api` should be kept at the<br>same version as the `org.apache.logging.log4j:log4j-core`<br>package to ensure compatability if in use. # Mitigation Log4j<br>2.16.0 fixes this issue by removing support for message<br>lookup patterns and disabling JNDI functionality by default.<br>This issue can be mitigated in prior releases (< 2.16.0) by<br>removing the JndiLookup class from the classpath (example:<br>zip -q -d log4j-core-*.jar<br>org/apache/logging/log4j/core/lookup/JndiLookup.class). Log4j<br>2.15.0 restricts JNDI LDAP lookups to localhost by default.<br>Note that previous mitigations involving configuration such<br>as to set the system property `log4j2.formatMsgNoLookups` to<br>`true` do NOT mitigate this specific vulnerability. |
| org.apache.logging.log4j:log4j-core:2.14.1 | CVE-2021-44228 | Critical  | # Summary Log4j versions prior to 2.16.0 are subject to a<br>remote code execution vulnerability via the ldap JNDI parser.<br>As per [Apache's Log4j security<br>guide](https://logging.apache.org/log4j/2.x/security.html):<br>Apache Log4j2 <=2.14.1 JNDI features used in configuration,<br>log messages, and parameters do not protect against attacker<br>controlled LDAP and other JNDI related endpoints. An attacker<br>who can control log messages or log message parameters can<br>execute arbitrary code loaded from LDAP servers when message<br>lookup substitution is enabled. From log4j 2.16.0, this<br>behavior has been disabled by default. Log4j version 2.15.0<br>contained an earlier fix for the vulnerability, but that<br>patch did not disable attacker-controlled JNDI lookups in all<br>situations. For more information, see the `Updated advice for<br>version 2.16.0` section of this advisory. # Impact Logging<br>untrusted or user controlled data with a vulnerable version<br>of Log4J may result in Remote Code Execution (RCE) against<br>your application. This includes untrusted data included in<br>logged errors such as exception traces, authentication<br>failures, and other unexpected vectors of user controlled<br>input. # Affected versions Any Log4J version prior to v2.15.0<br>is affected to this specific issue. The v1 branch of Log4J<br>which is considered End Of Life (EOL) is vulnerable to other<br>RCE vectors so the recommendation is to still update to<br>2.16.0 where possible. ## Security releases Additional<br>backports of this fix have been made available in versions<br>2.3.1, 2.12.2, and 2.12.3 ## Affected packages Only the<br>`org.apache.logging.log4j:log4j-core` package is directly<br>affected by this vulnerability. The<br>`org.apache.logging.log4j:log4j-api` should be kept at the<br>same version as the `org.apache.logging.log4j:log4j-core`<br>package to ensure compatability if in use. # Remediation<br>Advice ## Updated advice for version 2.16.0 The Apache<br>Logging Services team provided updated mitigation advice upon<br>the release of version 2.16.0, which [disables JNDI by<br>default and completely removes support for message<br>lookups](https://logging.apache.org/log4j/2.x/changes-report.html#a2.16.0).<br>Even in version 2.15.0, lookups used in layouts to provide<br>specific pieces of context information will still recursively<br>resolve, possibly triggering JNDI lookups. This problem is<br>being tracked as<br>[CVE-2021-45046](https://nvd.nist.gov/vuln/detail/CVE-2021-45046).<br>More information is available on the [GitHub Security<br>Advisory for<br>CVE-2021-45046](https://github.com/advisories/GHSA-7rjr-3q55-vv33).<br>Users who want to avoid attacker-controlled JNDI lookups but<br>cannot upgrade to 2.16.0 must [ensure that no such lookups<br>resolve to attacker-provided data and ensure that the the<br>JndiLookup class is not<br>loaded](https://issues.apache.org/jira/browse/LOG4J2-3221).<br>Please note that Log4J v1 is End Of Life (EOL) and will not<br>receive patches for this issue. Log4J v1 is also vulnerable<br>to other RCE vectors and we recommend you migrate to Log4J<br>2.16.0 where possible. |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2022-42004 | High  | Uncontrolled Resource Consumption in FasterXML<br>jackson-databind |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2022-42003 | High  | Uncontrolled Resource Consumption in Jackson-databind |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2021-46877 | High  | jackson-databind possible Denial of Service if using JDK<br>serialization to serialize JsonNode |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2020-36518 | High  | Deeply nested json in jackson-databind |
| org.apache.commons:commons-compress:1.21 | CVE-2024-25710 | High  | Apache Commons Compress: Denial of service caused by an<br>infinite loop for a corrupted DUMP file |
| org.apache.commons:commons-compress:1.21 | CVE-2024-26308 | Medium  | Apache Commons Compress: OutOfMemoryError unpacking broken<br>Pack200 file |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
