### PR TITLE
📦 Bump com.fasterxml.jackson.core:jackson-databind:2.12.3 from 2.12.3 to 2.12.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,12 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <groupId>com.example</groupId>
     <artifactId>my-app</artifactId>
     <version>1.0-SNAPSHOT</version>
-
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
-
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -27,7 +22,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.3</version>
+            <version>2.12.7.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -170,7 +165,6 @@
             <version>3.1</version>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| CVE ID  | Severity | Description       |
|-------|-----|-----------|
| CVE-2022-42004 | High  | Uncontrolled Resource Consumption in FasterXML jackson-databind |
| CVE-2022-42003 | High  | Uncontrolled Resource Consumption in Jackson-databind |
| CVE-2021-46877 | High  | jackson-databind possible Denial of Service if using JDK serialization to<br>serialize JsonNode |
| CVE-2020-36518 | High  | Deeply nested json in jackson-databind |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
