### PR TITLE
📦 Bump com.fasterxml.jackson.core:jackson-databind:2.13.2.1 from 2.13.2.1 to 2.13.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.2.1</version>
+            <version>2.13.4.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| CVE ID  | Severity | Description       |
|-------|-----|-----------|
| CVE-2022-42003 | High  | Uncontrolled Resource Consumption in Jackson-databind |
| CVE-2022-42004 | High  | Uncontrolled Resource Consumption in FasterXML jackson-databind |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
