### PR TITLE
📦 Bump com.fasterxml.jackson.core:jackson-databind:2.12.3 from 2.12.3 to 2.12.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,12 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <groupId>com.example</groupId>
     <artifactId>my-app</artifactId>
     <version>1.0-SNAPSHOT</version>
-
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
-
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -27,7 +22,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.3</version>
+            <version>2.13.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -170,7 +165,6 @@
             <version>3.1</version>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| CVE ID  | Severity | Description       |
|-------|-----|-----------|
| CVE-2022-42003 | High  | In FasterXML jackson-databind 2.4.0-rc1 until 2.12.7.1 and in 2.13.x before<br>2.13.4.2 resource exhaustion can occur because of a lack of a check in primitive<br>value deserializers to avoid deep wrapper array nesting, when the<br>UNWRAP_SINGLE_VALUE_ARRAYS feature is enabled. This was patched in 2.12.7.1,<br>2.13.4.2, and 2.14.0. Commits that introduced vulnerable code are<br>https://github.com/FasterXML/jackson-databind/commit/d499f2e7bbc5ebd63af11e1f5cf1989fa323aa45,<br>https://github.com/FasterXML/jackson-databind/commit/0e37a39502439ecbaa1a5b5188387c01bf7f7fa1,<br>and<br>https://github.com/FasterXML/jackson-databind/commit/7ba9ac5b87a9d6ac0d2815158ecbeb315ad4dcdc.<br>Fix commits are<br>https://github.com/FasterXML/jackson-databind/commit/cd090979b7ea78c75e4de8a4aed04f7e9fa8deea<br>and<br>https://github.com/FasterXML/jackson-databind/commit/d78d00ee7b5245b93103fef3187f70543d67ca33.<br>The `2.13.4.1` release does fix this issue, however it also references a<br>non-existent jackson-bom which causes build failures for gradle users. See<br>https://github.com/FasterXML/jackson-databind/issues/3627#issuecomment-1277957548<br>for details. This is fixed in `2.13.4.2` which is listed in the advisory metadata<br>so that users are not subjected to unnecessary build failures |
| CVE-2022-42004 | High  | In FasterXML jackson-databind before 2.12.7.1 and in 2.13.x before 2.13.4,<br>resource exhaustion can occur because of a lack of a check in<br>BeanDeserializer._deserializeFromArray to prevent use of deeply nested arrays.<br>This issue can only happen when the `UNWRAP_SINGLE_VALUE_ARRAYS` feature is<br>explicitly enabled. |
| CVE-2021-46877 | High  | jackson-databind 2.10.x through 2.12.x before 2.12.6 and 2.13.x before 2.13.1<br>allows attackers to cause a denial of service (2 GB transient heap usage per<br>read) in uncommon situations involving JsonNode JDK serialization. |
| CVE-2020-36518 | High  | jackson-databind is a data-binding package for the Jackson Data Processor.<br>jackson-databind allows a Java stack overflow exception and denial of service via<br>a large depth of nested objects. |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
