### PR TITLE
📦 Bump versions of multiple dependencies to address vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.14.1</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,12 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <groupId>com.example</groupId>
     <artifactId>my-app</artifactId>
     <version>1.0-SNAPSHOT</version>
-
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
-
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -27,7 +22,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.3</version>
+            <version>2.15.0-rc3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -170,7 +165,6 @@
             <version>3.1</version>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| Component | CVE ID  | Severity | Description       |
|-------|-------|-----|-----------|
| org.apache.logging.log4j:log4j-core:2.14.1 | CVE-2021-45046 | Critical  | # Impact The fix to address<br>[CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228)<br>in Apache Log4j 2.15.0 was incomplete in certain non-default<br>configurations. This could allow attackers with control over<br>Thread Context Map (MDC) input data when the logging<br>configuration uses a non-default Pattern Layout with either a<br>Context Lookup (for example, $${ctx:loginId}) or a Thread<br>Context Map pattern (%X, %mdc, or %MDC) to craft malicious<br>input data using a JNDI Lookup pattern resulting in a remote<br>code execution (RCE) attack. ## Affected packages Only the<br>`org.apache.logging.log4j:log4j-core` package is directly<br>affected by this vulnerability. The<br>`org.apache.logging.log4j:log4j-api` should be kept at the<br>same version as the `org.apache.logging.log4j:log4j-core`<br>package to ensure compatability if in use. # Mitigation Log4j<br>2.16.0 fixes this issue by removing support for message<br>lookup patterns and disabling JNDI functionality by default.<br>This issue can be mitigated in prior releases (< 2.16.0) by<br>removing the JndiLookup class from the classpath (example:<br>zip -q -d log4j-core-*.jar<br>org/apache/logging/log4j/core/lookup/JndiLookup.class). Log4j<br>2.15.0 restricts JNDI LDAP lookups to localhost by default.<br>Note that previous mitigations involving configuration such<br>as to set the system property `log4j2.formatMsgNoLookups` to<br>`true` do NOT mitigate this specific vulnerability. |
| org.apache.logging.log4j:log4j-core:2.14.1 | CVE-2021-44228 | Critical  | Apache Log4j2 2.0-beta9 through 2.15.0 (excluding security<br>releases 2.12.2, 2.12.3, and 2.3.1) JNDI features used in<br>configuration, log messages, and parameters do not protect<br>against attacker controlled LDAP and other JNDI related<br>endpoints. An attacker who can control log messages or log<br>message parameters can execute arbitrary code loaded from<br>LDAP servers when message lookup substitution is enabled.<br>From log4j 2.15.0, this behavior has been disabled by<br>default. From version 2.16.0 (along with 2.12.2, 2.12.3, and<br>2.3.1), this functionality has been completely removed. Note<br>that this vulnerability is specific to log4j-core and does<br>not affect log4net, log4cxx, or other Apache Logging Services<br>projects. |
| org.apache.logging.log4j:log4j-core:2.14.1 | GHSA-7RJR-3Q55-VV33 | Unknown  |  |
| org.apache.logging.log4j:log4j-core:2.14.1 | CVE-2021-45105 | Unknown  |  |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2022-42004 | High  | Uncontrolled Resource Consumption in FasterXML<br>jackson-databind |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2022-42003 | High  | Uncontrolled Resource Consumption in Jackson-databind |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2021-46877 | High  | jackson-databind possible Denial of Service if using JDK<br>serialization to serialize JsonNode |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2020-36518 | High  | Deeply nested json in jackson-databind |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
