### PR TITLE
📦 Bump versions of multiple dependencies to address vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,12 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <groupId>com.example</groupId>
     <artifactId>my-app</artifactId>
     <version>1.0-SNAPSHOT</version>
-
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
-
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -27,7 +22,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.3</version>
+            <version>2.12.7.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -170,7 +165,6 @@
             <version>3.1</version>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.14.1</version>
+            <version>2.15.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| Component | CVE ID  | Severity | Description       |
|-------|-------|-----|-----------|
| org.apache.logging.log4j:log4j-core:2.14.1 | CVE-2021-44228 | Critical  |  |
| org.apache.logging.log4j:log4j-core:2.14.1 | CVE-2021-45046 | Critical  |  |
| org.apache.logging.log4j:log4j-core:2.14.1 | CVE-2021-45105 | Medium  |  |
| org.apache.logging.log4j:log4j-core:2.14.1 | CVE-2021-44832 | Medium  |  |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2022-42004 | High  |  |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2022-42003 | High  |  |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2021-46877 | High  |  |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2020-36518 | High  |  |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
