### PR TITLE
📦 Bump versions of multiple dependencies to address vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,12 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <groupId>com.example</groupId>
     <artifactId>my-app</artifactId>
     <version>1.0-SNAPSHOT</version>
-
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
-
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -27,7 +22,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.3</version>
+            <version>2.12.7.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -170,7 +165,6 @@
             <version>3.1</version>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.14.1</version>
+            <version>2.15.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>5.3.9</version>
+            <version>5.2.19</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| Component | CVE ID  | Severity | Description       |
|-------|-------|-----|-----------|
| org.apache.logging.log4j:log4j-core:2.14.1 | CVE-2021-44228 | Critical  | Apache Log4j2 2.0-beta9 through 2.15.0 (excluding security<br>releases 2.12.2, 2.12.3, and 2.3.1) JNDI features used in<br>configuration, log messages, and parameters do not protect<br>against attacker controlled LDAP and other JNDI related<br>endpoints. An attacker who can control log messages or log<br>message parameters can execute arbitrary code loaded from<br>LDAP servers when message lookup substitution is enabled.<br>From log4j 2.15.0, this behavior has been disabled by<br>default. From version 2.16.0 (along with 2.12.2, 2.12.3, and<br>2.3.1), this functionality has been completely removed. Note<br>that this vulnerability is specific to log4j-core and does<br>not affect log4net, log4cxx, or other Apache Logging Services<br>projects. |
| org.apache.logging.log4j:log4j-core:2.14.1 | CVE-2021-45046 | Critical  | It was found that the fix to address CVE-2021-44228 in Apache<br>Log4j 2.15.0 was incomplete in certain non-default<br>configurations. This could allows attackers with control over<br>Thread Context Map (MDC) input data when the logging<br>configuration uses a non-default Pattern Layout with either a<br>Context Lookup (for example, $${ctx:loginId}) or a Thread<br>Context Map pattern (%X, %mdc, or %MDC) to craft malicious<br>input data using a JNDI Lookup pattern resulting in an<br>information leak and remote code execution in some<br>environments and local code execution in all environments.<br>Log4j 2.16.0 (Java 8) and 2.12.2 (Java 7) fix this issue by<br>removing support for message lookup patterns and disabling<br>JNDI functionality by default. |
| org.apache.logging.log4j:log4j-core:2.14.1 | CVE-2021-45105 | Medium  | Apache Log4j2 versions 2.0-alpha1 through 2.16.0 (excluding<br>2.12.3 and 2.3.1) did not protect from uncontrolled recursion<br>from self-referential lookups. This allows an attacker with<br>control over Thread Context Map data to cause a denial of<br>service when a crafted string is interpreted. This issue was<br>fixed in Log4j 2.17.0, 2.12.3, and 2.3.1. |
| org.apache.logging.log4j:log4j-core:2.14.1 | CVE-2021-44832 | Medium  | Apache Log4j2 versions 2.0-beta7 through 2.17.0 (excluding<br>security fix releases 2.3.2 and 2.12.4) are vulnerable to a<br>remote code execution (RCE) attack when a configuration uses<br>a JDBC Appender with a JNDI LDAP data source URI when an<br>attacker has control of the target LDAP server. This issue is<br>fixed by limiting JNDI data source names to the java protocol<br>in Log4j2 versions 2.17.1, 2.12.4, and 2.3.2. |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2022-42004 | High  | Uncontrolled Resource Consumption in FasterXML<br>jackson-databind |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2022-42003 | High  | Uncontrolled Resource Consumption in Jackson-databind |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2021-46877 | High  | jackson-databind possible Denial of Service if using JDK<br>serialization to serialize JsonNode |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2020-36518 | High  | Deeply nested json in jackson-databind |
| org.springframework:spring-core:5.3.9 | CVE-2021-22060 | Medium  | In Spring Framework versions 5.3.0 - 5.3.13, 5.2.0 - 5.2.18,<br>and older unsupported versions, it is possible for a user to<br>provide malicious input to cause the insertion of additional<br>log entries. This is a follow-up to CVE-2021-22096 that<br>protects against additional types of input and in more places<br>of the Spring Framework codebase. |
| org.springframework:spring-core:5.3.9 | CVE-2021-22096 | Medium  | In Spring Framework versions 5.3.0 - 5.3.10, 5.2.0 - 5.2.17,<br>and older unsupported versions, it is possible for a user to<br>provide malicious input to cause the insertion of additional<br>log entries. |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
