### PR TITLE
Devtask/lineaje task 752

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,11 @@
             <artifactId>batik-transcoder</artifactId>
             <version>1.17</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.santuario</groupId>
+            <artifactId>xmlsec</artifactId>
+            <version>2.3.4</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.14.1</version>
+            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,11 @@
             <artifactId>batik-bridge</artifactId>
             <version>1.17</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>batik-script</artifactId>
+            <version>1.17</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.9</version>
+            <version>1.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,11 @@
             <artifactId>okio</artifactId>
             <version>3.4.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>batik-bridge</artifactId>
+            <version>1.17</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,11 @@
             <artifactId>bcprov-jdk15on</artifactId>
             <version>1.78</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>batik-transcoder</artifactId>
+            <version>1.17</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,11 @@
             <artifactId>batik-script</artifactId>
             <version>1.17</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>batik-svgrasterizer</artifactId>
+            <version>1.17</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,11 @@
             <artifactId>batik-svgbrowser</artifactId>
             <version>1.14</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+            <version>2.0.24</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,11 @@
             <artifactId>woodstox-core</artifactId>
             <version>6.4.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio</artifactId>
+            <version>3.4.0</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.3</version>
+            <version>2.13.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-vfs2</artifactId>
-            <version>2.8.0</version>
+            <version>2.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,12 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <groupId>com.example</groupId>
     <artifactId>my-app</artifactId>
     <version>1.0-SNAPSHOT</version>
-
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
-
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -169,8 +164,12 @@
             <artifactId>commons-jexl3</artifactId>
             <version>3.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.78</version>
+        </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,11 @@
             <artifactId>xalan</artifactId>
             <version>2.7.3</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>batik-svgbrowser</artifactId>
+            <version>1.14</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,11 @@
             <artifactId>batik-svgrasterizer</artifactId>
             <version>1.17</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.15.0</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,11 @@
             <artifactId>pdfbox</artifactId>
             <version>2.0.24</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <version>6.4.0</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>5.3.9</version>
+            <version>5.3.14</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -224,6 +224,11 @@
             <artifactId>jackson-core</artifactId>
             <version>2.15.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>xmlgraphics-commons</artifactId>
+            <version>2.6</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>5.0.0</version>
+            <version>5.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,11 @@
             <artifactId>xmlsec</artifactId>
             <version>2.3.4</version>
         </dependency>
+        <dependency>
+            <groupId>xalan</groupId>
+            <artifactId>xalan</artifactId>
+            <version>2.7.3</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-configuration2</artifactId>
-            <version>2.7</version>
+            <version>2.10.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
<html>
<body>
<!--StartFragment-->
<p>
Lineaje has automatically created this pull request to resolve the following CVEs:
</p>
<table border="1" cellpadding="6" cellspacing="0" style="border-collapse: collapse;">
  <thead>
    <tr>
      <th>Component</th>
      <th>CVE ID</th>
      <th>Severity</th>
      <th>Description</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>org.apache.logging.log4j:log4j-core:2.14.1</td>
      <td><a href="https://github.com/advisories/GHSA-jfh8-c2jp-5v3q">CVE-2021-44228</a></td>
      <td>Critical</td>
      <td>Apache Log4j2 2.0-beta9 through 2.15.0 (excluding security releases 2.12.2, 2.12.3, and 2.3.1) JNDI features used in configuration, log messages, and parameters do not protect against attacker controlled LDAP and other JNDI related endpoints. An attacker who can control log messages or log message parameters can execute arbitrary code loaded from LDAP servers when message lookup substitution is enabled. From log4j 2.15.0, this behavior has been disabled by default. From version 2.16.0 (along with 2.12.2, 2.12.3, and 2.3.1), this functionality has been completely removed. Note that this vulnerability is specific to log4j-core and does not affect log4net, log4cxx, or other Apache Logging Services projects.</td>
    </tr>
    <tr>
      <td>org.apache.logging.log4j:log4j-core:2.14.1</td>
      <td><a href="https://github.com/advisories/GHSA-7rjr-3q55-vv33">CVE-2021-45046</a></td>
      <td>Critical</td>
      <td>It was found that the fix to address <a href="https://github.com/advisories/GHSA-jfh8-c2jp-5v3q">CVE-2021-44228</a> in Apache Log4j 2.15.0 was incomplete in certain non-default configurations. This could allows attackers with control over Thread Context Map (MDC) input data when the logging configuration uses a non-default Pattern Layout with either a Context Lookup (for example, $${ctx:loginId}) or a Thread Context Map pattern (%X, %mdc, or %MDC) to craft malicious input data using a JNDI Lookup pattern resulting in an information leak and remote code execution in some environments and local code execution in all environments. Log4j 2.16.0 (Java 8) and 2.12.2 (Java 7) fix this issue by removing support for message lookup patterns and disabling JNDI functionality by default.</td>
    </tr>
    <tr>
      <td>org.apache.logging.log4j:log4j-core:2.14.1</td>
      <td><a href="https://github.com/advisories/GHSA-p6xc-xr62-6r2g">CVE-2021-45105</a></td>
      <td>Medium</td>
      <td>Apache Log4j2 versions 2.0-alpha1 through 2.16.0 (excluding 2.12.3 and 2.3.1) did not protect from uncontrolled recursion from self-referential lookups. This allows an attacker with control over Thread Context Map data to cause a denial of service when a crafted string is interpreted. This issue was fixed in Log4j 2.17.0, 2.12.3, and 2.3.1.</td>
    </tr>
    <tr>
      <td>org.apache.logging.log4j:log4j-core:2.14.1</td>
      <td><a href="https://github.com/advisories/GHSA-8489-44mv-ggj8">CVE-2021-44832</a></td>
      <td>Medium</td>
      <td>Apache Log4j2 versions 2.0-beta7 through 2.17.0 (excluding security fix releases 2.3.2 and 2.12.4) are vulnerable to a remote code execution (RCE) attack when a configuration uses a JDBC Appender with a JNDI LDAP data source URI when an attacker has control of the target LDAP server. This issue is fixed by limiting JNDI data source names to the java protocol in Log4j2 versions 2.17.1, 2.12.4, and 2.3.2.</td>
    </tr>
    <tr>
      <td>com.fasterxml.jackson.core:jackson-databind:2.12.3</td>
      <td><a href="https://github.com/advisories/GHSA-rgv9-q543-rqg4">CVE-2022-42004</a></td>
      <td>High</td>
      <td>Uncontrolled Resource Consumption in FasterXML jackson-databind</td>
    </tr>
    <tr>
      <td>com.fasterxml.jackson.core:jackson-databind:2.12.3</td>
      <td><a href="https://github.com/advisories/GHSA-jjjh-jjxp-wpff">CVE-2022-42003</a></td>
      <td>High</td>
      <td>Uncontrolled Resource Consumption in Jackson-databind</td>
    </tr>
    <tr>
      <td>com.fasterxml.jackson.core:jackson-databind:2.12.3</td>
      <td><a href="https://github.com/advisories/GHSA-3x8x-79m2-3w2w">CVE-2021-46877</a></td>
      <td>High</td>
      <td>jackson-databind possible Denial of Service if using JDK serialization to serialize JsonNode</td>
    </tr>
    <tr>
      <td>com.fasterxml.jackson.core:jackson-databind:2.12.3</td>
      <td><a href="https://github.com/advisories/GHSA-57j2-w4cx-62h2">CVE-2020-36518</a></td>
      <td>High</td>
      <td>Deeply nested json in jackson-databind</td>
    </tr>
    <tr>
      <td>org.springframework:spring-core:5.3.9</td>
      <td><a href="https://github.com/advisories/GHSA-6gf2-pvqw-37ph">CVE-2021-22060</a></td>
      <td>Medium</td>
      <td>In Spring Framework versions 5.3.0 - 5.3.13, 5.2.0 - 5.2.18, and older unsupported versions, it is possible for a user to provide malicious input to cause the insertion of additional log entries. This is a follow-up to <a href="https://github.com/advisories/GHSA-rfmp-97jj-h8m6">CVE-2021-22096</a> that protects against additional types of input and in more places of the Spring Framework codebase.</td>
    </tr>
    <tr>
      <td>org.springframework:spring-core:5.3.9</td>
      <td><a href="https://github.com/advisories/GHSA-rfmp-97jj-h8m6">CVE-2021-22096</a></td>
      <td>Medium</td>
      <td>In Spring Framework versions 5.3.0 - 5.3.10, 5.2.0 - 5.2.17, and older unsupported versions, it is possible for a user to provide malicious input to cause the insertion of additional log entries.</td>
    </tr>
  </tbody>
</table>
<p>
You can merge this PR once the tests pass and the changes are reviewed.
</p>
<p>
Thank you for reviewing the update! 🚀
</p>
<!--EndFragment-->
</body>
</html>