### PR TITLE
📦 Bump versions of multiple dependencies to address vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.14.1</version>
+            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,11 @@
             <artifactId>xmlsec</artifactId>
             <version>2.3.4</version>
         </dependency>
+        <dependency>
+            <groupId>xalan</groupId>
+            <artifactId>xalan</artifactId>
+            <version>2.7.3</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,11 @@
             <artifactId>commons-jexl3</artifactId>
             <version>3.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.santuario</groupId>
+            <artifactId>xmlsec</artifactId>
+            <version>2.3.4</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,12 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <groupId>com.example</groupId>
     <artifactId>my-app</artifactId>
     <version>1.0-SNAPSHOT</version>
-
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
-
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -22,7 +17,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>5.3.9</version>
+            <version>5.3.14</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -170,7 +165,6 @@
             <version>3.1</version>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.3</version>
+            <version>2.13.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,11 @@
             <artifactId>xalan</artifactId>
             <version>2.7.3</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+            <version>2.0.24</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| Component | CVE ID  | Severity | Description       |
|-------|-------|-----|-----------|
| org.apache.logging.log4j:log4j-core:2.14.1 | CVE-2021-44832 | Medium  | Apache Log4j2 versions 2.0-beta7 through 2.17.0 (excluding<br>security fix releases 2.3.2 and 2.12.4) are vulnerable to a<br>remote code execution (RCE) attack when a configuration uses<br>a JDBC Appender with a JNDI LDAP data source URI when an<br>attacker has control of the target LDAP server. This issue is<br>fixed by limiting JNDI data source names to the java protocol<br>in Log4j2 versions 2.17.1, 2.12.4, and 2.3.2. |
| org.apache.logging.log4j:log4j-core:2.14.1 | CVE-2021-45105 | Medium  | Apache Log4j2 versions 2.0-alpha1 through 2.16.0 (excluding<br>2.12.3 and 2.3.1) did not protect from uncontrolled recursion<br>from self-referential lookups. This allows an attacker with<br>control over Thread Context Map data to cause a denial of<br>service when a crafted string is interpreted. This issue was<br>fixed in Log4j 2.17.0, 2.12.3, and 2.3.1. |
| org.apache.logging.log4j:log4j-core:2.14.1 | CVE-2021-44228 | Critical  | Apache Log4j2 2.0-beta9 through 2.15.0 (excluding security<br>releases 2.12.2, 2.12.3, and 2.3.1) JNDI features used in<br>configuration, log messages, and parameters do not protect<br>against attacker controlled LDAP and other JNDI related<br>endpoints. An attacker who can control log messages or log<br>message parameters can execute arbitrary code loaded from<br>LDAP servers when message lookup substitution is enabled.<br>From log4j 2.15.0, this behavior has been disabled by<br>default. From version 2.16.0 (along with 2.12.2, 2.12.3, and<br>2.3.1), this functionality has been completely removed. Note<br>that this vulnerability is specific to log4j-core and does<br>not affect log4net, log4cxx, or other Apache Logging Services<br>projects. |
| org.apache.logging.log4j:log4j-core:2.14.1 | CVE-2021-45046 | Critical  | It was found that the fix to address CVE-2021-44228 in Apache<br>Log4j 2.15.0 was incomplete in certain non-default<br>configurations. This could allows attackers with control over<br>Thread Context Map (MDC) input data when the logging<br>configuration uses a non-default Pattern Layout with either a<br>Context Lookup (for example, $${ctx:loginId}) or a Thread<br>Context Map pattern (%X, %mdc, or %MDC) to craft malicious<br>input data using a JNDI Lookup pattern resulting in an<br>information leak and remote code execution in some<br>environments and local code execution in all environments.<br>Log4j 2.16.0 (Java 8) and 2.12.2 (Java 7) fix this issue by<br>removing support for message lookup patterns and disabling<br>JNDI functionality by default. |
| xalan:xalan:2.7.2 | CVE-2022-34169 | High  | The Apache Xalan Java XSLT library is vulnerable to an<br>integer truncation issue when processing malicious XSLT<br>stylesheets. This can be used to corrupt Java class files<br>generated by the internal XSLTC compiler and execute<br>arbitrary Java bytecode. Users are recommended to update to<br>version 2.7.3 or later. Note: Java runtimes (such as OpenJDK)<br>include repackaged copies of Xalan. |
| org.apache.pdfbox:pdfbox:2.0.22 | CVE-2021-31812 | Medium  | In Apache PDFBox, a carefully crafted PDF file can trigger an<br>infinite loop while loading the file. This issue affects<br>Apache PDFBox version 2.0.23 and prior 2.0.x versions. |
| org.apache.pdfbox:pdfbox:2.0.22 | CVE-2021-31811 | Medium  | In Apache PDFBox, a carefully crafted PDF file can trigger an<br>OutOfMemory-Exception while loading the file. This issue<br>affects Apache PDFBox version 2.0.23 and prior 2.0.x<br>versions. |
| org.apache.pdfbox:pdfbox:2.0.22 | CVE-2021-27906 | Medium  | A carefully crafted PDF file can trigger an<br>OutOfMemory-Exception while loading the file. This issue<br>affects Apache PDFBox version 2.0.22 and prior 2.0.x<br>versions. |
| org.apache.pdfbox:pdfbox:2.0.22 | CVE-2021-27807 | Medium  | A carefully crafted PDF file can trigger an infinite loop<br>while loading the file. This issue affects Apache PDFBox<br>version 2.0.22 and prior 2.0.x versions. |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2022-42004 | High  | Uncontrolled Resource Consumption in FasterXML<br>jackson-databind |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2022-42003 | High  | Uncontrolled Resource Consumption in Jackson-databind |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2021-46877 | High  | jackson-databind possible Denial of Service if using JDK<br>serialization to serialize JsonNode |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | GHSA-57J2-W4CX-62H2 | High  | jackson-databind is a data-binding package for the Jackson<br>Data Processor. jackson-databind allows a Java stack overflow<br>exception and denial of service via a large depth of nested<br>objects. |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2020-36518 | High  | Deeply nested json in jackson-databind |
| org.springframework:spring-core:5.3.9 | CVE-2021-22060 | Medium  | In Spring Framework versions 5.3.0 - 5.3.13, 5.2.0 - 5.2.18,<br>and older unsupported versions, it is possible for a user to<br>provide malicious input to cause the insertion of additional<br>log entries. This is a follow-up to CVE-2021-22096 that<br>protects against additional types of input and in more places<br>of the Spring Framework codebase. |
| org.springframework:spring-core:5.3.9 | CVE-2021-22096 | Medium  | In Spring Framework versions 5.3.0 - 5.3.10, 5.2.0 - 5.2.17,<br>and older unsupported versions, it is possible for a user to<br>provide malicious input to cause the insertion of additional<br>log entries. |
| org.apache.santuario:xmlsec:2.2.1 | CVE-2021-40690 | High  | All versions of Apache Santuario - XML Security for Java<br>prior to 2.2.3 and 2.1.7 are vulnerable to an issue where the<br>"secureValidation" property is not passed correctly when<br>creating a KeyInfo from a KeyInfoReference element. This<br>allows an attacker to abuse an XPath Transform to extract any<br>local .xml files in a RetrievalMethod element. |
| org.apache.santuario:xmlsec:2.2.1 | CVE-2023-44483 | Medium  | All versions of Apache Santuario - XML Security for Java<br>prior to 2.2.6, 2.3.4, and 3.0.3, when using the JSR 105 API,<br>are vulnerable to an issue where a private key may be<br>disclosed in log files when generating an XML Signature and<br>logging with debug level is enabled. Users are recommended to<br>upgrade to version 2.2.6, 2.3.4, or 3.0.3, which fixes this<br>issue. |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
