### PR TITLE
📦 Bump org.springframework:spring-beans:5.2.20.RELEASE from 5.2.20.RELEASE to 5.2.25.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
             <version>5.2.20.RELEASE</version>
+            <version>5.2.25.RELEASE</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| CVE ID  | Severity | Description       |
|-------|-----|-----------|
| CVE-2022-22970 | High  | In spring framework versions prior to 5.3.20+ , 5.2.22+ and old unsupported<br>versions, applications that handle file uploads are vulnerable to DoS attack if<br>they rely on data binding to set a MultipartFile or javax.servlet.Part to a field<br>in a model object. |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
