### PR TITLE
📦 Bump versions of multiple dependencies to address vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,16 @@
           <version>2.7.3</version>
 
         </dependency>
+
+        <dependency>
+
+          <groupId>org.apache.santuario</groupId>
+
+          <artifactId>xmlsec</artifactId>
+
+          <version>2.2.5</version>
+
+        </dependency>
 </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,18 @@
             <artifactId>commons-jexl3</artifactId>
             <version>3.1</version>
         </dependency>
-    </dependencies>
+    
+
+        <dependency>
+
+          <groupId>com.fasterxml.jackson.core</groupId>
+
+          <artifactId>jackson-core</artifactId>
+
+          <version>2.12.5</version>
+
+        </dependency>
+</dependencies>
 
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,16 @@
           <version>2.12.5</version>
 
         </dependency>
+
+        <dependency>
+
+          <groupId>xalan</groupId>
+
+          <artifactId>xalan</artifactId>
+
+          <version>2.7.3</version>
+
+        </dependency>
 </dependencies>
 
     <build>


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| Component | CVE ID  | Severity | Description       |
|-------|-------|-----|-----------|
| org.springframework:spring-core:5.3.9 | CVE-2021-22060 | Medium  | In Spring Framework versions 5.3.0 - 5.3.13, 5.2.0 - 5.2.18,<br>and older unsupported versions, it is possible for a user to<br>provide malicious input to cause the insertion of additional<br>log entries. This is a follow-up to CVE-2021-22096 that<br>protects against additional types of input and in more places<br>of the Spring Framework codebase. |
| org.springframework:spring-core:5.3.9 | CVE-2021-22096 | Medium  | In Spring Framework versions 5.3.0 - 5.3.10, 5.2.0 - 5.2.17,<br>and older unsupported versions, it is possible for a user to<br>provide malicious input to cause the insertion of additional<br>log entries. |
| org.springframework:spring-core:5.3.9 | CVE-2025-41249 | High  | The Spring Framework annotation detection mechanism may not<br>correctly resolve annotations on methods within type<br>hierarchies with a parameterized super type with unbounded<br>generics. This can be an issue if such annotations are used<br>for authorization decisions. Your application may be affected<br>by this if you are using Spring Security's<br>@EnableMethodSecurity feature. You are not affected by this<br>if you are not using @EnableMethodSecurity or if you do not<br>use security annotations on methods in generic superclasses<br>or generic interfaces. This CVE is published in conjunction<br>with CVE-2025-41248 https://spring.io/security/cve-2025-41248<br>. |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2021-46877 | High  | jackson-databind 2.10.x through 2.12.x before 2.12.6 and<br>2.13.x before 2.13.1 allows attackers to cause a denial of<br>service (2 GB transient heap usage per read) in uncommon<br>situations involving JsonNode JDK serialization. |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2020-36518 | High  | jackson-databind is a data-binding package for the Jackson<br>Data Processor. jackson-databind allows a Java stack overflow<br>exception and denial of service via a large depth of nested<br>objects. |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2022-42003 | High  | In FasterXML jackson-databind 2.4.0-rc1 until 2.12.7.1 and in<br>2.13.x before 2.13.4.2 resource exhaustion can occur because<br>of a lack of a check in primitive value deserializers to<br>avoid deep wrapper array nesting, when the<br>UNWRAP_SINGLE_VALUE_ARRAYS feature is enabled. This was<br>patched in 2.12.7.1, 2.13.4.2, and 2.14.0. Commits that<br>introduced vulnerable code are<br>https://github.com/FasterXML/jackson-databind/commit/d499f2e7bbc5ebd63af11e1f5cf1989fa323aa45,<br>https://github.com/FasterXML/jackson-databind/commit/0e37a39502439ecbaa1a5b5188387c01bf7f7fa1,<br>and<br>https://github.com/FasterXML/jackson-databind/commit/7ba9ac5b87a9d6ac0d2815158ecbeb315ad4dcdc.<br>Fix commits are<br>https://github.com/FasterXML/jackson-databind/commit/cd090979b7ea78c75e4de8a4aed04f7e9fa8deea<br>and<br>https://github.com/FasterXML/jackson-databind/commit/d78d00ee7b5245b93103fef3187f70543d67ca33.<br>The `2.13.4.1` release does fix this issue, however it also<br>references a non-existent jackson-bom which causes build<br>failures for gradle users. See<br>https://github.com/FasterXML/jackson-databind/issues/3627#issuecomment-1277957548<br>for details. This is fixed in `2.13.4.2` which is listed in<br>the advisory metadata so that users are not subjected to<br>unnecessary build failures |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2022-42004 | High  | In FasterXML jackson-databind before 2.12.7.1 and in 2.13.x<br>before 2.13.4, resource exhaustion can occur because of a<br>lack of a check in BeanDeserializer._deserializeFromArray to<br>prevent use of deeply nested arrays. This issue can only<br>happen when the `UNWRAP_SINGLE_VALUE_ARRAYS` feature is<br>explicitly enabled. |
| com.fasterxml.jackson.core:jackson-core:2.12.3 | CVE-2025-52999 | High  | ### Impact With older versions of jackson-core, if you parse<br>an input file and it has deeply nested data, Jackson could<br>end up throwing a StackoverflowError if the depth is<br>particularly large. ### Patches jackson-core 2.15.0 contains<br>a configurable limit for how deep Jackson will traverse in an<br>input document, defaulting to an allowable depth of 1000.<br>Change is in<br>https://github.com/FasterXML/jackson-core/pull/943.<br>jackson-core will throw a StreamConstraintsException if the<br>limit is reached. jackson-databind also benefits from this<br>change because it uses jackson-core to parse JSON inputs. ###<br>Workarounds Users should avoid parsing input files from<br>untrusted sources. |
| com.fasterxml.jackson.core:jackson-core:2.12.3 | CVE-2025-49128 | Medium  | ### Overview A flaw in Jackson-core's<br>`JsonLocation._appendSourceDesc` method allows up to 500<br>bytes of unintended memory content to be included in<br>exception messages. When parsing JSON from a byte array with<br>an offset and length, the exception message incorrectly reads<br>from the beginning of the array instead of the logical<br>payload start. This results in possible **information<br>disclosure** in systems using **pooled or reused buffers**,<br>like Netty or Vert.x. ### Details The vulnerability affects<br>the creation of exception messages like: ```<br>JsonParseException: Unexpected character ... at [Source:<br>(byte[])...] ``` When `JsonFactory.createParser(byte[] data,<br>int offset, int len)` is used, and an error occurs while<br>parsing, the exception message should include a snippet from<br>the specified logical payload. However, the method<br>`_appendSourceDesc` ignores the `offset`, and always starts<br>reading from index `0`. If the buffer contains residual<br>sensitive data from a previous request, such as credentials<br>or document contents, that data may be exposed if the<br>exception is propagated to the client. The issue particularly<br>impacts server applications using: * Pooled byte buffers<br>(e.g., Netty) * Frameworks that surface parse errors in HTTP<br>responses * Default Jackson settings (i.e.,<br>`INCLUDE_SOURCE_IN_LOCATION` is enabled) A documented<br>real-world example is<br>[CVE-2021-22145](https://nvd.nist.gov/vuln/detail/CVE-2021-22145)<br>in Elasticsearch, which stemmed from the same root cause. ###<br>Attack Scenario An attacker sends malformed JSON to a service<br>using Jackson and pooled byte buffers (e.g., Netty-based HTTP<br>servers). If the server reuses a buffer and includes the<br>parser’s exception in its HTTP 400 response, the attacker<br>may receive residual data from previous requests. ### Proof<br>of Concept ```java byte[] buffer = new byte[1000];<br>System.arraycopy("SECRET".getBytes(), 0, buffer, 0, 6);<br>System.arraycopy("{ \"bad\": }".getBytes(), 0, buffer, 700,<br>10); JsonFactory factory = new JsonFactory(); JsonParser<br>parser = factory.createParser(buffer, 700, 20);<br>parser.nextToken(); // throws exception // Exception message<br>will include "SECRET" ``` ### Patches This issue was silently<br>fixed in jackson-core version 2.13.0, released on September<br>30, 2021, via [PR<br>#652](https://github.com/FasterXML/jackson-core/pull/652).<br>All users should upgrade to version 2.13.0 or later. ###<br>Workarounds If upgrading is not immediately possible,<br>applications can mitigate the issue by: 1. **Disabling<br>exception message exposure to clients** — avoid returning<br>parsing exception messages in HTTP responses. 2. **Disabling<br>source inclusion in exceptions** by setting: ```java<br>jsonFactory.disable(JsonFactory.Feature.INCLUDE_SOURCE_IN_LOCATION);<br>``` This prevents Jackson from embedding any source content<br>in exception messages, avoiding leakage. ### References *<br>[Pull Request #652 (Fix<br>implementation)](https://github.com/FasterXML/jackson-core/pull/652)<br>* [CVE-2021-22145 (Elasticsearch exposure of this<br>flaw)](https://nvd.nist.gov/vuln/detail/CVE-2021-22145) |
| xalan:xalan:2.7.2 | CVE-2022-34169 | High  | The Apache Xalan Java XSLT library is vulnerable to an<br>integer truncation issue when processing malicious XSLT<br>stylesheets. This can be used to corrupt Java class files<br>generated by the internal XSLTC compiler and execute<br>arbitrary Java bytecode. A fix for this issue was published<br>in September 2022 as part of an anticipated 2.7.3 release. |
| org.apache.santuario:xmlsec:2.2.1 | CVE-2023-44483 | Medium  | All versions of Apache Santuario - XML Security for Java<br>prior to 2.2.6, 2.3.4, and 3.0.3, when using the JSR 105 API,<br>are vulnerable to an issue where a private key may be<br>disclosed in log files when generating an XML Signature and<br>logging with debug level is enabled. Users are recommended to<br>upgrade to version 2.2.6, 2.3.4, or 3.0.3, which fixes this<br>issue. |
| org.apache.santuario:xmlsec:2.2.1 | CVE-2021-40690 | High  | All versions of Apache Santuario - XML Security for Java<br>prior to 2.2.3 and 2.1.7 are vulnerable to an issue where the<br>"secureValidation" property is not passed correctly when<br>creating a KeyInfo from a KeyInfoReference element. This<br>allows an attacker to abuse an XPath Transform to extract any<br>local .xml files in a RetrievalMethod element. |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
