### PR TITLE
📦 Bump versions of multiple dependencies to address vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,16 @@
           <version>5.4.0</version>
 
         </dependency>
+
+        <dependency>
+
+          <groupId>commons-io</groupId>
+
+          <artifactId>commons-io</artifactId>
+
+          <version>2.7</version>
+
+        </dependency>
 </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,16 @@
           <version>2.7</version>
 
         </dependency>
+
+        <dependency>
+
+          <groupId>com.squareup.okio</groupId>
+
+          <artifactId>okio</artifactId>
+
+          <version>1.17.6</version>
+
+        </dependency>
 </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,16 @@
           <version>2.2.3</version>
 
         </dependency>
+
+        <dependency>
+
+          <groupId>org.apache.xmlgraphics</groupId>
+
+          <artifactId>batik-svgbrowser</artifactId>
+
+          <version>1.14</version>
+
+        </dependency>
 </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,16 @@
           <version>1.14</version>
 
         </dependency>
+
+        <dependency>
+
+          <groupId>org.apache.pdfbox</groupId>
+
+          <artifactId>pdfbox</artifactId>
+
+          <version>2.0.24</version>
+
+        </dependency>
 </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,16 @@
           <version>1.17</version>
 
         </dependency>
+
+        <dependency>
+
+          <groupId>org.bouncycastle</groupId>
+
+          <artifactId>bcprov-jdk15on</artifactId>
+
+          <version>1.78</version>
+
+        </dependency>
 </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,16 @@
           <version>2.0.24</version>
 
         </dependency>
+
+        <dependency>
+
+          <groupId>xalan</groupId>
+
+          <artifactId>xalan</artifactId>
+
+          <version>2.7.3</version>
+
+        </dependency>
 </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -290,6 +290,16 @@
           <version>2.15.0</version>
 
         </dependency>
+
+        <dependency>
+
+          <groupId>org.apache.xmlgraphics</groupId>
+
+          <artifactId>batik-script</artifactId>
+
+          <version>1.17</version>
+
+        </dependency>
 </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,18 @@
             <artifactId>commons-jexl3</artifactId>
             <version>3.1</version>
         </dependency>
-    </dependencies>
+    
+
+        <dependency>
+
+          <groupId>org.apache.xmlgraphics</groupId>
+
+          <artifactId>batik-transcoder</artifactId>
+
+          <version>1.17</version>
+
+        </dependency>
+</dependencies>
 
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -300,6 +300,16 @@
           <version>1.17</version>
 
         </dependency>
+
+        <dependency>
+
+          <groupId>org.apache.xmlgraphics</groupId>
+
+          <artifactId>xmlgraphics-commons</artifactId>
+
+          <version>2.6</version>
+
+        </dependency>
 </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,16 @@
           <version>2.7.3</version>
 
         </dependency>
+
+        <dependency>
+
+          <groupId>com.fasterxml.woodstox</groupId>
+
+          <artifactId>woodstox-core</artifactId>
+
+          <version>5.4.0</version>
+
+        </dependency>
 </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,16 @@
           <version>1.17.6</version>
 
         </dependency>
+
+        <dependency>
+
+          <groupId>org.apache.xmlgraphics</groupId>
+
+          <artifactId>batik-bridge</artifactId>
+
+          <version>1.17</version>
+
+        </dependency>
 </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,16 @@
           <version>1.17</version>
 
         </dependency>
+
+        <dependency>
+
+          <groupId>com.fasterxml.jackson.core</groupId>
+
+          <artifactId>jackson-core</artifactId>
+
+          <version>2.15.0</version>
+
+        </dependency>
 </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,16 @@
           <version>1.78</version>
 
         </dependency>
+
+        <dependency>
+
+          <groupId>org.apache.santuario</groupId>
+
+          <artifactId>xmlsec</artifactId>
+
+          <version>2.2.3</version>
+
+        </dependency>
 </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,16 @@
           <version>1.17</version>
 
         </dependency>
+
+        <dependency>
+
+          <groupId>org.apache.xmlgraphics</groupId>
+
+          <artifactId>batik-svgrasterizer</artifactId>
+
+          <version>1.17</version>
+
+        </dependency>
 </dependencies>
 
     <build>


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| Component | CVE ID  | Severity | Description       |
|-------|-------|-----|-----------|
| org.apache.commons:commons-compress:1.21 | GHSA-4265-CCF5-PHJ5 | Medium  | Allocation of Resources Without Limits or Throttling<br>vulnerability in Apache Commons Compress. This issue affects<br>Apache Commons Compress: from 1.21 before 1.26. Users are<br>recommended to upgrade to version 1.26, which fixes the<br>issue. |
| org.apache.commons:commons-compress:1.21 | CVE-2024-25710 | High  | Apache Commons Compress: Denial of service caused by an<br>infinite loop for a corrupted DUMP file |
| org.apache.commons:commons-compress:1.21 | CVE-2024-26308 | Medium  | Allocation of Resources Without Limits or Throttling<br>vulnerability in Apache Commons Compress.This issue affects<br>Apache Commons Compress: from 1.21 before 1.26. Users are<br>recommended to upgrade to version 1.26, which fixes the<br>issue. |
| org.apache.commons:commons-vfs2:2.8.0 | CVE-2025-30474 | Medium  | Exposure of Sensitive Information to an Unauthorized Actor<br>vulnerability in Apache Commons VFS. The FtpFileObject class<br>can throw an exception when a file is not found, revealing<br>the original URI in its message, which may include a<br>password. The fix is to mask the password in the exception<br>message This issue affects Apache Commons VFS: before 2.10.0.<br>Users are recommended to upgrade to version 2.10.0, which<br>fixes the issue. |
| org.apache.commons:commons-vfs2:2.8.0 | CVE-2025-27553 | High  | Relative Path Traversal vulnerability in Apache Commons VFS<br>before 2.10.0. The FileObject API in Commons VFS has a<br>'resolveFile' method that takes a 'scope' parameter.<br>Specifying 'NameScope.DESCENDENT' promises that "an exception<br>is thrown if the resolved file is not a descendent of the<br>base file". However, when the path contains encoded ".."<br>characters (for example, "%2E%2E/bar.txt"), it might return<br>file objects that are not a descendent of the base file,<br>without throwing an exception. This issue affects Apache<br>Commons VFS: before 2.10.0. Users are recommended to upgrade<br>to version 2.10.0, which fixes the issue. |
| org.apache.commons:commons-text:1.9 | CVE-2022-42889 | Critical  | Apache Commons Text performs variable interpolation, allowing<br>properties to be dynamically evaluated and expanded. The<br>standard format for interpolation is "${prefix:name}", where<br>"prefix" is used to locate an instance of<br>org.apache.commons.text.lookup.StringLookup that performs the<br>interpolation. Starting with version 1.5 and continuing<br>through 1.9, the set of default Lookup instances included<br>interpolators that could result in arbitrary code execution<br>or contact with remote servers. These lookups are: - "script"<br>- execute expressions using the JVM script execution engine<br>(javax.script) - "dns" - resolve dns records - "url" - load<br>values from urls, including from remote servers Applications<br>using the interpolation defaults in the affected versions may<br>be vulnerable to remote code execution or unintentional<br>contact with remote servers if untrusted configuration values<br>are used. Users are recommended to upgrade to Apache Commons<br>Text 1.10.0, which disables the problematic interpolators by<br>default. |
| com.fasterxml.jackson.core:jackson-core:2.12.3 | GHSA-H46C-H94J-95F3 | High  | ### Impact With older versions of jackson-core, if you parse<br>an input file and it has deeply nested data, Jackson could<br>end up throwing a StackoverflowError if the depth is<br>particularly large. ### Patches jackson-core 2.15.0 contains<br>a configurable limit for how deep Jackson will traverse in an<br>input document, defaulting to an allowable depth of 1000.<br>Change is in<br>https://github.com/FasterXML/jackson-core/pull/943.<br>jackson-core will throw a StreamConstraintsException if the<br>limit is reached. jackson-databind also benefits from this<br>change because it uses jackson-core to parse JSON inputs. ###<br>Workarounds Users should avoid parsing input files from<br>untrusted sources. |
| com.fasterxml.jackson.core:jackson-core:2.12.3 | CVE-2025-49128 | Medium  | Jackson-core contains core low-level incremental<br>("streaming") parser and generator abstractions used by<br>Jackson Data Processor. Starting in version 2.0.0 and prior<br>to version 2.13.0, a flaw in jackson-core's<br>`JsonLocation._appendSourceDesc` method allows up to 500<br>bytes of unintended memory content to be included in<br>exception messages. When parsing JSON from a byte array with<br>an offset and length, the exception message incorrectly reads<br>from the beginning of the array instead of the logical<br>payload start. This results in possible information<br>disclosure in systems using pooled or reused buffers, like<br>Netty or Vert.x. This issue was silently fixed in<br>jackson-core version 2.13.0, released on September 30, 2021,<br>via PR #652. All users should upgrade to version 2.13.0 or<br>later. If upgrading is not immediately possible, applications<br>can mitigate the issue by disabling exception message<br>exposure to clients to avoid returning parsing exception<br>messages in HTTP responses and/or disabling source inclusion<br>in exceptions to prevent Jackson from embedding any source<br>content in exception messages, avoiding leakage. |
| com.fasterxml.jackson.core:jackson-core:2.12.3 | GHSA-WF8F-6423-GFXG | Medium  | ### Overview A flaw in Jackson-core's<br>`JsonLocation._appendSourceDesc` method allows up to 500<br>bytes of unintended memory content to be included in<br>exception messages. When parsing JSON from a byte array with<br>an offset and length, the exception message incorrectly reads<br>from the beginning of the array instead of the logical<br>payload start. This results in possible **information<br>disclosure** in systems using **pooled or reused buffers**,<br>like Netty or Vert.x. ### Details The vulnerability affects<br>the creation of exception messages like: ```<br>JsonParseException: Unexpected character ... at [Source:<br>(byte[])...] ``` When `JsonFactory.createParser(byte[] data,<br>int offset, int len)` is used, and an error occurs while<br>parsing, the exception message should include a snippet from<br>the specified logical payload. However, the method<br>`_appendSourceDesc` ignores the `offset`, and always starts<br>reading from index `0`. If the buffer contains residual<br>sensitive data from a previous request, such as credentials<br>or document contents, that data may be exposed if the<br>exception is propagated to the client. The issue particularly<br>impacts server applications using: * Pooled byte buffers<br>(e.g., Netty) * Frameworks that surface parse errors in HTTP<br>responses * Default Jackson settings (i.e.,<br>`INCLUDE_SOURCE_IN_LOCATION` is enabled) A documented<br>real-world example is<br>[CVE-2021-22145](https://nvd.nist.gov/vuln/detail/CVE-2021-22145)<br>in Elasticsearch, which stemmed from the same root cause. ###<br>Attack Scenario An attacker sends malformed JSON to a service<br>using Jackson and pooled byte buffers (e.g., Netty-based HTTP<br>servers). If the server reuses a buffer and includes the<br>parser’s exception in its HTTP 400 response, the attacker<br>may receive residual data from previous requests. ### Proof<br>of Concept ```java byte[] buffer = new byte[1000];<br>System.arraycopy("SECRET".getBytes(), 0, buffer, 0, 6);<br>System.arraycopy("{ \"bad\": }".getBytes(), 0, buffer, 700,<br>10); JsonFactory factory = new JsonFactory(); JsonParser<br>parser = factory.createParser(buffer, 700, 20);<br>parser.nextToken(); // throws exception // Exception message<br>will include "SECRET" ``` ### Patches This issue was silently<br>fixed in jackson-core version 2.13.0, released on September<br>30, 2021, via [PR<br>#652](https://github.com/FasterXML/jackson-core/pull/652).<br>All users should upgrade to version 2.13.0 or later. ###<br>Workarounds If upgrading is not immediately possible,<br>applications can mitigate the issue by: 1. **Disabling<br>exception message exposure to clients** — avoid returning<br>parsing exception messages in HTTP responses. 2. **Disabling<br>source inclusion in exceptions** by setting: ```java<br>jsonFactory.disable(JsonFactory.Feature.INCLUDE_SOURCE_IN_LOCATION);<br>``` This prevents Jackson from embedding any source content<br>in exception messages, avoiding leakage. ### References *<br>[Pull Request #652 (Fix<br>implementation)](https://github.com/FasterXML/jackson-core/pull/652)<br>* [CVE-2021-22145 (Elasticsearch exposure of this<br>flaw)](https://nvd.nist.gov/vuln/detail/CVE-2021-22145) |
| org.apache.poi:poi-ooxml:5.0.0 | CVE-2025-31672 | Medium  | Improper Input Validation vulnerability in Apache POI. The<br>issue affects the parsing of OOXML format files like xlsx,<br>docx and pptx. These file formats are basically zip files and<br>it is possible for malicious users to add zip entries with<br>duplicate names (including the path) in the zip. In this<br>case, products reading the affected file could read different<br>data because 1 of the zip entries with the duplicate name is<br>selected over another but different products may choose a<br>different zip entry. This issue affects Apache POI poi-ooxml<br>before 5.4.0. poi-ooxml 5.4.0 has a check that throws an<br>exception if zip entries with duplicate file names are found<br>in the input file. Users are recommended to upgrade to<br>version poi-ooxml 5.4.0, which fixes the issue. Please read<br>https://poi.apache.org/security.html for recommendations<br>about how to use the POI libraries securely. |
| com.fasterxml.woodstox:woodstox-core:5.2.1 | CVE-2022-40152 | Medium  | Those using Woodstox to parse XML data may be vulnerable to<br>Denial of Service attacks (DOS) if DTD support is enabled. If<br>the parser is running on user supplied input, an attacker may<br>supply content that causes the parser to crash by<br>stackoverflow. This effect may support a denial of service<br>attack. |
| org.apache.xmlgraphics:batik-bridge:1.13 | CVE-2022-44729 | High  | Server-Side Request Forgery (SSRF) vulnerability in Apache<br>Software Foundation Apache XML Graphics Batik.This issue<br>affects Apache XML Graphics Batik: 1.16. On version 1.16, a<br>malicious SVG could trigger loading external resources by<br>default, causing resource consumption or in some cases even<br>information disclosure. Users are recommended to upgrade to<br>version 1.17 or later. |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2022-42004 | High  | Uncontrolled Resource Consumption in FasterXML<br>jackson-databind |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2022-42003 | High  | Uncontrolled Resource Consumption in Jackson-databind |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2021-46877 | High  | jackson-databind possible Denial of Service if using JDK<br>serialization to serialize JsonNode |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | GHSA-57J2-W4CX-62H2 | High  | jackson-databind is a data-binding package for the Jackson<br>Data Processor. jackson-databind allows a Java stack overflow<br>exception and denial of service via a large depth of nested<br>objects. |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2020-36518 | High  | Deeply nested json in jackson-databind |
| org.apache.logging.log4j:log4j-core:2.14.1 | CVE-2021-44832 | Medium  | Apache Log4j2 versions 2.0-beta7 through 2.17.0 (excluding<br>security fix releases 2.3.2 and 2.12.4) are vulnerable to a<br>remote code execution (RCE) attack when a configuration uses<br>a JDBC Appender with a JNDI LDAP data source URI when an<br>attacker has control of the target LDAP server. This issue is<br>fixed by limiting JNDI data source names to the java protocol<br>in Log4j2 versions 2.17.1, 2.12.4, and 2.3.2. |
| org.apache.logging.log4j:log4j-core:2.14.1 | CVE-2021-45105 | Medium  | Apache Log4j2 versions 2.0-alpha1 through 2.16.0 (excluding<br>2.12.3 and 2.3.1) did not protect from uncontrolled recursion<br>from self-referential lookups. This allows an attacker with<br>control over Thread Context Map data to cause a denial of<br>service when a crafted string is interpreted. This issue was<br>fixed in Log4j 2.17.0, 2.12.3, and 2.3.1. |
| org.apache.logging.log4j:log4j-core:2.14.1 | CVE-2021-44228 | Critical  | Apache Log4j2 2.0-beta9 through 2.15.0 (excluding security<br>releases 2.12.2, 2.12.3, and 2.3.1) JNDI features used in<br>configuration, log messages, and parameters do not protect<br>against attacker controlled LDAP and other JNDI related<br>endpoints. An attacker who can control log messages or log<br>message parameters can execute arbitrary code loaded from<br>LDAP servers when message lookup substitution is enabled.<br>From log4j 2.15.0, this behavior has been disabled by<br>default. From version 2.16.0 (along with 2.12.2, 2.12.3, and<br>2.3.1), this functionality has been completely removed. Note<br>that this vulnerability is specific to log4j-core and does<br>not affect log4net, log4cxx, or other Apache Logging Services<br>projects. |
| org.apache.logging.log4j:log4j-core:2.14.1 | CVE-2021-45046 | Critical  | It was found that the fix to address CVE-2021-44228 in Apache<br>Log4j 2.15.0 was incomplete in certain non-default<br>configurations. This could allows attackers with control over<br>Thread Context Map (MDC) input data when the logging<br>configuration uses a non-default Pattern Layout with either a<br>Context Lookup (for example, $${ctx:loginId}) or a Thread<br>Context Map pattern (%X, %mdc, or %MDC) to craft malicious<br>input data using a JNDI Lookup pattern resulting in an<br>information leak and remote code execution in some<br>environments and local code execution in all environments.<br>Log4j 2.16.0 (Java 8) and 2.12.2 (Java 7) fix this issue by<br>removing support for message lookup patterns and disabling<br>JNDI functionality by default. |
| org.apache.xmlgraphics:batik-script:1.13 | CVE-2022-44730 | Medium  | Server-Side Request Forgery (SSRF) vulnerability in Apache<br>Software Foundation Apache XML Graphics Batik.This issue<br>affects Apache XML Graphics Batik: 1.16. A malicious SVG can<br>probe user profile / data and send it directly as parameter<br>to a URL. |
| org.apache.santuario:xmlsec:2.2.1 | CVE-2021-40690 | High  | All versions of Apache Santuario - XML Security for Java<br>prior to 2.2.3 and 2.1.7 are vulnerable to an issue where the<br>"secureValidation" property is not passed correctly when<br>creating a KeyInfo from a KeyInfoReference element. This<br>allows an attacker to abuse an XPath Transform to extract any<br>local .xml files in a RetrievalMethod element. |
| org.apache.santuario:xmlsec:2.2.1 | CVE-2023-44483 | Medium  | All versions of Apache Santuario - XML Security for Java<br>prior to 2.2.6, 2.3.4, and 3.0.3, when using the JSR 105 API,<br>are vulnerable to an issue where a private key may be<br>disclosed in log files when generating an XML Signature and<br>logging with debug level is enabled. Users are recommended to<br>upgrade to version 2.2.6, 2.3.4, or 3.0.3, which fixes this<br>issue. |
| xalan:xalan:2.7.2 | CVE-2022-34169 | High  | The Apache Xalan Java XSLT library is vulnerable to an<br>integer truncation issue when processing malicious XSLT<br>stylesheets. This can be used to corrupt Java class files<br>generated by the internal XSLTC compiler and execute<br>arbitrary Java bytecode. Users are recommended to update to<br>version 2.7.3 or later. Note: Java runtimes (such as OpenJDK)<br>include repackaged copies of Xalan. |
| org.apache.xmlgraphics:batik-svgbrowser:1.13 | CVE-2020-11987 | High  | Apache Batik 1.13 is vulnerable to server-side request<br>forgery, caused by improper input validation by the<br>NodePickerPanel. By using a specially-crafted argument, an<br>attacker could exploit this vulnerability to cause the<br>underlying server to make arbitrary GET requests. |
| org.apache.pdfbox:pdfbox:2.0.22 | CVE-2021-31812 | Medium  | In Apache PDFBox, a carefully crafted PDF file can trigger an<br>infinite loop while loading the file. This issue affects<br>Apache PDFBox version 2.0.23 and prior 2.0.x versions. |
| org.apache.pdfbox:pdfbox:2.0.22 | CVE-2021-31811 | Medium  | In Apache PDFBox, a carefully crafted PDF file can trigger an<br>OutOfMemory-Exception while loading the file. This issue<br>affects Apache PDFBox version 2.0.23 and prior 2.0.x<br>versions. |
| org.apache.pdfbox:pdfbox:2.0.22 | CVE-2021-27906 | Medium  | A carefully crafted PDF file can trigger an<br>OutOfMemory-Exception while loading the file. This issue<br>affects Apache PDFBox version 2.0.22 and prior 2.0.x<br>versions. |
| org.apache.pdfbox:pdfbox:2.0.22 | CVE-2021-27807 | Medium  | A carefully crafted PDF file can trigger an infinite loop<br>while loading the file. This issue affects Apache PDFBox<br>version 2.0.22 and prior 2.0.x versions. |
| commons-io:commons-io:1.3.1 | CVE-2021-29425 | Medium  | In Apache Commons IO before 2.7, When invoking the method<br>FileNameUtils.normalize with an improper input string, like<br>"//../foo", or "\\..\foo", the result would be the same<br>value, thus possibly providing access to files in the parent<br>directory, but not further above (thus "limited" path<br>traversal), if the calling code would use the result to<br>construct a path value. |
| com.squareup.okio:okio:1.6.0 | CVE-2023-3635 | Medium  | GzipSource does not handle an exception that might be raised<br>when parsing a malformed gzip buffer. This may lead to denial<br>of service of the Okio client when handling a crafted GZIP<br>archive, by using the GzipSource class. |
| org.apache.commons:commons-configuration2:2.7 | CVE-2024-29133 | Medium  | Out-of-bounds Write vulnerability in Apache Commons<br>Configuration.This issue affects Apache Commons<br>Configuration: from 2.0 before 2.10.1. Users are recommended<br>to upgrade to version 2.10.1, which fixes the issue. |
| org.apache.commons:commons-configuration2:2.7 | CVE-2024-29131 | High  | Apache Commons Configuration: StackOverflowError adding<br>property in AbstractListDelimiterHandler.flattenIterator() |
| org.apache.commons:commons-configuration2:2.7 | CVE-2022-33980 | Critical  | Apache Commons Configuration performs variable interpolation,<br>allowing properties to be dynamically evaluated and expanded.<br>The standard format for interpolation is "${prefix:name}",<br>where "prefix" is used to locate an instance of<br>org.apache.commons.configuration2.interpol.Lookup that<br>performs the interpolation. Starting with version 2.4 and<br>continuing through 2.7, the set of default Lookup instances<br>included interpolators that could result in arbitrary code<br>execution or contact with remote servers. These lookups are:<br>- "script" - execute expressions using the JVM script<br>execution engine (javax.script) - "dns" - resolve dns records<br>- "url" - load values from urls, including from remote<br>servers Applications using the interpolation defaults in the<br>affected versions may be vulnerable to remote code execution<br>or unintentional contact with remote servers if untrusted<br>configuration values are used. Users are recommended to<br>upgrade to Apache Commons Configuration 2.8.0, which disables<br>the problematic interpolators by default. |
| org.apache.xmlgraphics:batik-transcoder:1.13 | CVE-2022-44729 | High  | Server-Side Request Forgery (SSRF) vulnerability in Apache<br>Software Foundation Apache XML Graphics Batik.This issue<br>affects Apache XML Graphics Batik: 1.16. On version 1.16, a<br>malicious SVG could trigger loading external resources by<br>default, causing resource consumption or in some cases even<br>information disclosure. Users are recommended to upgrade to<br>version 1.17 or later. |
| org.bouncycastle:bcprov-jdk15on:1.68 | CVE-2024-29857 | Medium  | An issue was discovered in ECCurve.java and ECCurve.cs in<br>Bouncy Castle Java (BC Java) before 1.78, BC Java LTS before<br>2.73.6, BC-FJA before 1.0.2.5, and BC C# .Net before 2.3.1.<br>Importing an EC certificate with crafted F2m parameters can<br>lead to excessive CPU consumption during the evaluation of<br>the curve parameters. |
| org.bouncycastle:bcprov-jdk15on:1.68 | CVE-2024-30171 | Medium  | An issue was discovered in Bouncy Castle Java TLS API and<br>JSSE Provider before 1.78. Timing-based leakage may occur in<br>RSA based handshakes because of exception processing. |
| org.bouncycastle:bcprov-jdk15on:1.68 | CVE-2024-30172 | Unknown  |  |
| org.bouncycastle:bcprov-jdk15on:1.68 | CVE-2023-33202 | Medium  | Bouncy Castle for Java before 1.73 contains a potential<br>Denial of Service (DoS) issue within the Bouncy Castle<br>org.bouncycastle.openssl.PEMParser class. This class parses<br>OpenSSL PEM encoded streams containing X.509 certificates,<br>PKCS8 encoded keys, and PKCS7 objects. Parsing a file that<br>has crafted ASN.1 data through the PEMParser causes an<br>OutOfMemoryError, which can enable a denial of service<br>attack. |
| org.bouncycastle:bcprov-jdk15on:1.68 | CVE-2023-33201 | Medium  | Bouncy Castle provides the `X509LDAPCertStoreSpi.java` class<br>which can be used in conjunction with the CertPath API for<br>validating certificate paths. Pre-1.73 the implementation did<br>not check the X.500 name of any certificate, subject, or<br>issuer being passed in for LDAP wild cards, meaning the<br>presence of a wild car may lead to Information Disclosure. A<br>potential attack would be to generate a self-signed<br>certificate with a subject name that contains special<br>characters, e.g: `CN=Subject*)(objectclass=`. This will be<br>included into the filter and provides the attacker ability to<br>specify additional attributes in the search query. This can<br>be exploited as a blind LDAP injection: an attacker can<br>enumerate valid attribute values using the boolean blind<br>injection technique. The exploitation depends on the<br>structure of the target LDAP directory, as well as what kind<br>of errors are exposed to the user. Changes to the<br>`X509LDAPCertStoreSpi.java` class add the additional checking<br>of any X.500 name used to correctly escape wild card<br>characters. |
| org.apache.xmlgraphics:xmlgraphics-commons:2.4 | CVE-2020-11988 | High  | Apache XmlGraphics Commons 2.4 is vulnerable to server-side<br>request forgery, caused by improper input validation by the<br>XMPParser. By using a specially-crafted argument, an attacker<br>could exploit this vulnerability to cause the underlying<br>server to make arbitrary GET requests. |
| org.springframework:spring-core:5.3.9 | CVE-2021-22060 | Medium  | In Spring Framework versions 5.3.0 - 5.3.13, 5.2.0 - 5.2.18,<br>and older unsupported versions, it is possible for a user to<br>provide malicious input to cause the insertion of additional<br>log entries. This is a follow-up to CVE-2021-22096 that<br>protects against additional types of input and in more places<br>of the Spring Framework codebase. |
| org.springframework:spring-core:5.3.9 | CVE-2021-22096 | Medium  | In Spring Framework versions 5.3.0 - 5.3.10, 5.2.0 - 5.2.17,<br>and older unsupported versions, it is possible for a user to<br>provide malicious input to cause the insertion of additional<br>log entries. |
| org.apache.xmlgraphics:batik-svgrasterizer:1.13 | CVE-2022-44729 | High  | Server-Side Request Forgery (SSRF) vulnerability in Apache<br>Software Foundation Apache XML Graphics Batik.This issue<br>affects Apache XML Graphics Batik: 1.16. On version 1.16, a<br>malicious SVG could trigger loading external resources by<br>default, causing resource consumption or in some cases even<br>information disclosure. Users are recommended to upgrade to<br>version 1.17 or later. |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
